### PR TITLE
Add a STABS symbol table analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ hs_err_pid*
 # vscode generated files
 *.vscode
 
+/bin/
+/os/linux_x86_64/
+/os/mac_x86_64/
+/os/win_x86_64/

--- a/os/README.md
+++ b/os/README.md
@@ -1,0 +1,6 @@
+Put your stdump executables here. If this is a release build of Ghidra Emotion Engine: Reloaded, these files should already be included.
+
+Valid locations are:
+- `os/linux_x86_64/stdump`
+- `os/mac_x86_64/stdump`
+- `os/win_x86_64/stdump.exe`

--- a/os/README.md
+++ b/os/README.md
@@ -1,4 +1,4 @@
-Put your stdump executables here. If this is a release build of Ghidra Emotion Engine: Reloaded, these files should already be included.
+Put your [stdump](https://github.com/chaoticgd/ccc) executables here. If this is a release build of Ghidra Emotion Engine: Reloaded, these files should already be included.
 
 Valid locations are:
 - `os/linux_x86_64/stdump`

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsAnalyzer.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsAnalyzer.java
@@ -24,10 +24,6 @@ public class StabsAnalyzer extends AbstractAnalyzer {
 			" from the link below, and put it in the os/ directory.\n\n" +
 			"For more information see:\n" +
 			"https://github.com/chaoticgd/ccc";
-	
-	public static final String OPTION_IMPORT_DATA_TYPES = "Import Data Types";
-	public static final String OPTION_IMPORT_DATA_TYPES_DESC =
-			"Import deduplicated data types from the symbol table into Ghidra.";
 
 	public static final String OPTION_IMPORT_FUNCTIONS = "Import Function";
 	public static final String OPTION_IMPORT_FUNCTIONS_DESC =
@@ -84,7 +80,6 @@ public class StabsAnalyzer extends AbstractAnalyzer {
 	
 	@Override
 	public void registerOptions(Options options, Program program) {
-		options.registerOption(OPTION_IMPORT_DATA_TYPES, DEFAULT_OPTIONS.importDataTypes, null, OPTION_IMPORT_DATA_TYPES);
 		options.registerOption(OPTION_IMPORT_FUNCTIONS, DEFAULT_OPTIONS.importFunctions, null, OPTION_IMPORT_FUNCTIONS);
 		options.registerOption(OPTION_IMPORT_GLOBALS, DEFAULT_OPTIONS.importGlobals, null, OPTION_IMPORT_GLOBALS);
 		options.registerOption(OPTION_INLINED_CODE, DEFAULT_OPTIONS.markInlinedCode, null, OPTION_INLINED_CODE);
@@ -95,7 +90,6 @@ public class StabsAnalyzer extends AbstractAnalyzer {
 	
 	@Override
 	public void optionsChanged(Options options, Program program) {
-		importOptions.importDataTypes = options.getBoolean(OPTION_IMPORT_DATA_TYPES, DEFAULT_OPTIONS.importDataTypes);
 		importOptions.importFunctions = options.getBoolean(OPTION_IMPORT_FUNCTIONS, DEFAULT_OPTIONS.importFunctions);
 		importOptions.importGlobals = options.getBoolean(OPTION_IMPORT_GLOBALS, DEFAULT_OPTIONS.importGlobals);
 		importOptions.markInlinedCode = options.getBoolean(OPTION_INLINED_CODE, DEFAULT_OPTIONS.markInlinedCode);

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsAnalyzer.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsAnalyzer.java
@@ -55,6 +55,7 @@ public class StabsAnalyzer extends AbstractAnalyzer {
 	
 	private StabsImporter.ImportOptions importOptions = new StabsImporter.ImportOptions();
 	private StabsImporter.ImportOptions DEFAULT_OPTIONS = new StabsImporter.ImportOptions();
+	StabsImporter importer = null;
 	
 	public StabsAnalyzer() {
 		super(STABS_ANALYZER_NAME, STABS_ANALYZER_DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
@@ -77,7 +78,7 @@ public class StabsAnalyzer extends AbstractAnalyzer {
 	@Override
 	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
 			throws CancelledException {
-		StabsImporter importer = new StabsImporter(program, importOptions, monitor, log);
+		importer = new StabsImporter(program, importOptions, monitor, log);
 		return importer.doImport();
 	}
 	

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsAnalyzer.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsAnalyzer.java
@@ -1,0 +1,106 @@
+package ghidra.emotionengine.symboltable;
+
+import ghidra.app.services.AbstractAnalyzer;
+import ghidra.app.services.AnalysisPriority;
+import ghidra.app.services.AnalyzerType;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.framework.options.Options;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.lang.Language;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.TaskMonitor;
+
+public class StabsAnalyzer extends AbstractAnalyzer {
+	
+	public static final String STABS_ANALYZER_NAME = "STABS";
+	public static final String STABS_ANALYZER_DESCRIPTION =
+			"Parses STABS symbols from a .mdebug section to extract information" +
+			" about data types, functions and global variables." +
+			" Most of this process is handled by stdump, a C++ program which is" +
+			" bundled with releases of Ghidra Emotion Engine: Reloaded. If this" +
+			" file is missing, grab stdump " + StdumpParser.SUPPORTED_STDUMP_VERSION +
+			" from the link below, and put it in the os/ directory.\n\n" +
+			"For more information see:\n" +
+			"https://github.com/chaoticgd/ccc";
+	
+	public static final String OPTION_IMPORT_DATA_TYPES = "Import Data Types";
+	public static final String OPTION_IMPORT_DATA_TYPES_DESC =
+			"Import deduplicated data types from the symbol table into Ghidra.";
+
+	public static final String OPTION_IMPORT_FUNCTIONS = "Import Function";
+	public static final String OPTION_IMPORT_FUNCTIONS_DESC =
+			"Import functions from the symbol table into Ghidra.";
+	
+	public static final String OPTION_IMPORT_GLOBALS = "Import Global Variables";
+	public static final String OPTION_IMPORT_GLOBALS_DESC =
+			"Import global variables from the STABS symbols into Ghidra.";
+	
+	public static final String OPTION_INLINED_CODE = "Mark Inlined Code";
+	public static final String OPTION_INLINED_CODE_DESC =
+			"Mark inlined code using pre comments.";
+	
+	public static final String OPTION_LINE_NUMBERS = "Output Line Numbers";
+	public static final String OPTION_LINE_NUMBERS_DESC =
+			"Output source line numbers as end-of-line comments that will appear in the diassembly.";
+	
+	public static final String OPTION_OVERRIDE_ELF_PATH = "Override ELF Path (Optional)";
+	public static final String OPTION_OVERRIDE_ELF_PATH_DESC =
+			"Use and ELF file of your choice as input to stdump instead of the currently loaded program.";
+	
+	public static final String OPTION_OVERRIDE_JSON_PATH = "Override JSON Path (Optional)";
+	public static final String OPTION_OVERRIDE_JSON_PATH_DESC =
+			"Parse a JSON file of your choice instead of running stdump and using its output.";
+	
+	private StabsImporter.ImportOptions importOptions = new StabsImporter.ImportOptions();
+	private StabsImporter.ImportOptions DEFAULT_OPTIONS = new StabsImporter.ImportOptions();
+	
+	public StabsAnalyzer() {
+		super(STABS_ANALYZER_NAME, STABS_ANALYZER_DESCRIPTION, AnalyzerType.BYTE_ANALYZER);
+		setPriority(AnalysisPriority.FORMAT_ANALYSIS.after());
+	}
+	
+	@Override
+	public boolean getDefaultEnablement(Program program) {
+		MemoryBlock section = program.getMemory().getBlock(".mdebug");
+		return section != null;
+	}
+	
+	@Override
+	public boolean canAnalyze(Program program) {
+		Language language = program.getLanguage();
+		String id = language.getLanguageID().getIdAsString().toLowerCase();
+		return id.startsWith("mips") || id.startsWith("r5900");
+	}
+	
+	@Override
+	public boolean added(Program program, AddressSetView set, TaskMonitor monitor, MessageLog log)
+			throws CancelledException {
+		StabsImporter importer = new StabsImporter(program, importOptions, monitor, log);
+		return importer.doImport();
+	}
+	
+	@Override
+	public void registerOptions(Options options, Program program) {
+		options.registerOption(OPTION_IMPORT_DATA_TYPES, DEFAULT_OPTIONS.importDataTypes, null, OPTION_IMPORT_DATA_TYPES);
+		options.registerOption(OPTION_IMPORT_FUNCTIONS, DEFAULT_OPTIONS.importFunctions, null, OPTION_IMPORT_FUNCTIONS);
+		options.registerOption(OPTION_IMPORT_GLOBALS, DEFAULT_OPTIONS.importGlobals, null, OPTION_IMPORT_GLOBALS);
+		options.registerOption(OPTION_INLINED_CODE, DEFAULT_OPTIONS.markInlinedCode, null, OPTION_INLINED_CODE);
+		options.registerOption(OPTION_LINE_NUMBERS, DEFAULT_OPTIONS.outputLineNumbers, null, OPTION_LINE_NUMBERS);
+		options.registerOption(OPTION_OVERRIDE_ELF_PATH, DEFAULT_OPTIONS.overrideElfPath, null, OPTION_OVERRIDE_ELF_PATH_DESC);
+		options.registerOption(OPTION_OVERRIDE_JSON_PATH, DEFAULT_OPTIONS.overrideJsonPath, null, OPTION_OVERRIDE_JSON_PATH_DESC);
+	}
+	
+	@Override
+	public void optionsChanged(Options options, Program program) {
+		importOptions.importDataTypes = options.getBoolean(OPTION_IMPORT_DATA_TYPES, DEFAULT_OPTIONS.importDataTypes);
+		importOptions.importFunctions = options.getBoolean(OPTION_IMPORT_FUNCTIONS, DEFAULT_OPTIONS.importFunctions);
+		importOptions.importGlobals = options.getBoolean(OPTION_IMPORT_GLOBALS, DEFAULT_OPTIONS.importGlobals);
+		importOptions.markInlinedCode = options.getBoolean(OPTION_INLINED_CODE, DEFAULT_OPTIONS.markInlinedCode);
+		importOptions.outputLineNumbers = options.getBoolean(OPTION_LINE_NUMBERS, DEFAULT_OPTIONS.outputLineNumbers);
+		importOptions.overrideElfPath = options.getString(OPTION_OVERRIDE_ELF_PATH, DEFAULT_OPTIONS.overrideElfPath);
+		importOptions.overrideJsonPath = options.getString(OPTION_OVERRIDE_JSON_PATH, DEFAULT_OPTIONS.overrideJsonPath);
+	}
+	
+}

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
@@ -422,12 +422,13 @@ public class StabsImporter extends FlatProgramAPI {
 		InputStream stdout = process.getInputStream();
 		InputStream stderr = process.getErrorStream();
 		BufferedReader errorReader = new BufferedReader(new InputStreamReader(stderr));
-		int returnCode = process.waitFor();
+		byte[] output = stdout.readAllBytes();
 		while(errorReader.ready()) {
 			log.appendMsg("STABS", stripColourCodes(errorReader.readLine()));
 		}
+		int returnCode = process.waitFor();
 		if(returnCode == 0) {
-			return stdout.readAllBytes();
+			return output;
 		} else {
 			return null;
 		}

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
@@ -1,0 +1,432 @@
+package ghidra.emotionengine.symboltable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import ghidra.app.cmd.function.CreateFunctionCmd;
+import ghidra.app.util.exporter.ElfExporter;
+import ghidra.app.util.exporter.ExporterException;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.framework.Application;
+import ghidra.framework.Platform;
+import ghidra.program.flatapi.FlatProgramAPI;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataUtilities;
+import ghidra.program.model.data.DataUtilities.ClearDataMode;
+import ghidra.program.model.data.PointerDataType;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.LocalVariable;
+import ghidra.program.model.listing.LocalVariableImpl;
+import ghidra.program.model.listing.ParameterImpl;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.Variable;
+import ghidra.program.model.symbol.SourceType;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.SymbolTable;
+import ghidra.program.model.util.CodeUnitInsertionException;
+import ghidra.util.exception.DuplicateNameException;
+import ghidra.util.exception.InvalidInputException;
+import ghidra.util.task.TaskMonitor;
+
+public class StabsImporter extends FlatProgramAPI {
+
+	public static class ImportOptions {
+		boolean importDataTypes = true;
+		boolean importFunctions = true;
+		boolean importGlobals = true;
+		boolean markInlinedCode = true;
+		boolean outputLineNumbers = true;
+		String overrideElfPath = "";
+		String overrideJsonPath = "";
+	}
+	
+	Program program;
+	ImportOptions options;
+	TaskMonitor monitor;
+	MessageLog log;
+	
+	public StabsImporter(Program p, ImportOptions o, TaskMonitor m, MessageLog l) {
+		super(p, m);
+		program = p;
+		options = o;
+		monitor = m;
+		log = l;
+	}
+
+	public boolean doImport() {
+		File elfFile = null;
+		boolean deleteElfAfterwards = false;
+		File jsonFile = null;
+		boolean deleteJsonAfterwards = false;
+		byte[] jsonOutput = null;
+		if(options.overrideJsonPath.isBlank()) {
+			// The JSON file doesn't already exist, so create it as a temporary
+			// file so we can have stdump write its output to it.
+			try {
+				jsonFile = File.createTempFile("stdump_output", ".json");
+			} catch (IOException e) {
+				log.appendException(e);
+				return false;
+			}
+			deleteJsonAfterwards = true;
+			
+			// Determine where to load the ELF file from, or create it from the
+			// current program if a path wasn't manually specified.
+			if(options.overrideElfPath.isBlank()) {
+				// The ELF file doesn't already exist, so here we create a
+				// new temporary file.
+				try {
+					elfFile = File.createTempFile("stdump_input", ".elf");
+				} catch (IOException e) {
+					log.appendException(e);
+					jsonFile.delete();
+					return false;
+				}
+				deleteElfAfterwards = true;
+				
+				// Write the contents of the current program to the ELF file.
+				ElfExporter exporter = new ElfExporter();
+				if(exporter.canExportDomainObject(program.getClass())) {
+					try {
+						exporter.export(elfFile, program, null, monitor);
+					} catch (ExporterException | IOException e) {
+						log.appendException(e);
+						elfFile.delete();
+						jsonFile.delete();
+						return false;
+					}
+				} else {
+					log.appendMsg("ElfExporter.canExportDomainObject(program.getClass()) returned false.");
+					return false;
+				}
+			} else {
+				// A custom ELF file was specified, so we don't create one.
+				elfFile = new File(options.overrideElfPath);
+				deleteElfAfterwards = false;
+			}
+			
+			// Run stdump.
+			try {
+				jsonOutput = runStdump(elfFile.getAbsolutePath(), monitor, log);
+				if(jsonOutput == null) {
+					if(deleteElfAfterwards) {
+						elfFile.delete();
+					}
+					jsonFile.delete();
+					return false;
+				}
+			} catch (IOException e) {
+				log.appendException(e);
+				if(deleteElfAfterwards) {
+					elfFile.delete();
+				}
+				jsonFile.delete();
+				return false;
+			}
+		} else {
+			// A custom JSON file was specified, so we don't need to run stdump.
+			jsonFile = new File(options.overrideJsonPath);
+			try {
+				FileInputStream stream = new FileInputStream(jsonFile);
+				jsonOutput = stream.readAllBytes();
+				stream.close();
+			} catch (IOException e) {
+				log.appendException(e);
+				return false;
+			}
+			deleteJsonAfterwards = false;
+			deleteElfAfterwards = false;
+		}
+		
+		// Parse the JSON file into an AST.
+		StdumpAST.ParsedJsonFile ast;
+		try {
+			ast = StdumpParser.readJson(jsonOutput);
+		} catch (FileNotFoundException e) {
+			log.appendException(e);
+			if(deleteElfAfterwards && elfFile != null) {
+				elfFile.delete();
+			}
+			return false;
+		}
+		
+		// Now actually import all this data into Ghidra.
+		StdumpAST.ImporterState importer = new StdumpAST.ImporterState();
+		importer.markInlinedCode = options.markInlinedCode;
+		importer.outputLineNumbers = options.outputLineNumbers;
+		importer.ast = ast;
+		importer.monitor = monitor;
+		importer.log = log;
+		importer.programTypeManager = program.getDataTypeManager();
+		if(options.importDataTypes) {
+			importDataTypes(importer);
+		}
+		if(options.importFunctions) {
+			importFunctions(importer, program);
+		}
+		if(options.importGlobals) {
+			importGlobalVariables(importer);
+		}
+		
+		// Cleanup.
+		if(deleteElfAfterwards && elfFile != null) {
+			elfFile.delete();
+		}
+		if(deleteJsonAfterwards) {
+			jsonFile.delete();
+		}
+		
+		return true;
+	}
+	
+	public void importDataTypes(StdumpAST.ImporterState importer) {
+		// Gather information required for type lookup.
+		for(StdumpAST.Node node : importer.ast.files) {
+			StdumpAST.SourceFile file = (StdumpAST.SourceFile) node;
+			importer.stabsTypeNumberToDeduplicatedTypeIndex.add(file.stabsTypeNumberToDeduplicatedTypeIndex);
+		}
+
+		for(int i = 0; i < importer.ast.deduplicatedTypes.size(); i++) {
+			StdumpAST.Node node = importer.ast.deduplicatedTypes.get(i);
+			if(node.name != null && !node.name.isEmpty()) {
+				importer.typeNameToDeduplicatedTypeIndex.put(node.name, i);
+			}
+		}
+
+		// Create all the top-level enums, structs and unions first.
+		for(int i = 0; i < importer.ast.deduplicatedTypes.size(); i++) {
+			StdumpAST.Node node = importer.ast.deduplicatedTypes.get(i);
+			if(node instanceof StdumpAST.InlineEnum) {
+				StdumpAST.InlineEnum inline_enum = (StdumpAST.InlineEnum) node;
+				DataType type = inline_enum.createType(importer);
+				importer.types.add(importer.programTypeManager.addDataType(type, null));
+			} else if(node instanceof StdumpAST.InlineStructOrUnion) {
+				StdumpAST.InlineStructOrUnion struct_or_union = (StdumpAST.InlineStructOrUnion) node;
+				DataType type = struct_or_union.create_empty(importer);
+				importer.types.add(importer.programTypeManager.addDataType(type, null));
+			} else {
+				importer.types.add(null);
+			}
+		}
+
+		// Fill in the structs and unions recursively.
+		for(int i = 0; i < importer.ast.deduplicatedTypes.size(); i++) {
+			StdumpAST.Node node = importer.ast.deduplicatedTypes.get(i);
+			if(node instanceof StdumpAST.InlineStructOrUnion) {
+				StdumpAST.InlineStructOrUnion struct_or_union = (StdumpAST.InlineStructOrUnion) node;
+				DataType type = importer.types.get(i);
+				struct_or_union.fill(type, importer);
+				importer.types.set(i, type);
+			}
+		}
+	}
+	
+	public void importFunctions(StdumpAST.ImporterState importer, Program program) {
+		for(StdumpAST.Node node : importer.ast.files) {
+			StdumpAST.SourceFile sourceFile = (StdumpAST.SourceFile) node;
+			for(StdumpAST.Node function_node : sourceFile.functions) {
+				StdumpAST.FunctionDefinition def = (StdumpAST.FunctionDefinition) function_node;
+				StdumpAST.FunctionType type = (StdumpAST.FunctionType) def.type;
+				if(def.addressRange.valid()) {
+					// Find or create the function.
+					Address low = toAddr(def.addressRange.low);
+					Address high = toAddr(def.addressRange.high - 1);
+					AddressSet range = new AddressSet(low, high);
+					Function function = findOrCreateFunction(def, low, high, range);
+					setFunctionName(function, def, sourceFile, low);
+					if(type.returnType != null) {
+						try {
+							function.setReturnType(type.returnType.createType(importer), SourceType.ANALYSIS);
+						} catch (InvalidInputException e) {
+							log.appendException(e);
+						}
+					}
+					HashSet<String> parameterNames = fillInParameters(function, importer, def, type);
+					if(importer.outputLineNumbers) {
+						for(StdumpAST.LineNumberPair pair : def.lineNumbers) {
+							setEOLComment(toAddr(pair.address), "Line " + Integer.toString(pair.lineNumber));
+						}
+					}
+					if(importer.markInlinedCode) {
+						markInlinedCode(def, sourceFile);
+					}
+					fillInLocalVariables(function, importer, def, parameterNames);
+				}
+			}
+		}
+	}
+
+	private Function findOrCreateFunction(StdumpAST.FunctionDefinition def, Address low, Address high, AddressSet range) {
+		Function function = getFunctionAt(low);
+		if(function == null) {
+			CreateFunctionCmd cmd;
+			if(high.getOffset() < low.getOffset()) {
+				cmd = new CreateFunctionCmd(new AddressSet(low), SourceType.ANALYSIS);
+			} else {
+				cmd = new CreateFunctionCmd(def.name, low, range, SourceType.ANALYSIS);
+			}
+			boolean success = cmd.applyTo(program, monitor);
+			if(!success) {
+				log.appendMsg("Failed to create function " + def.name + ": " + cmd.getStatusMsg());
+			}
+			function = getFunctionAt(low);
+		}
+		return function;
+	}
+	
+	private void setFunctionName(Function function, StdumpAST.FunctionDefinition def,
+			StdumpAST.SourceFile sourceFile, Address low) {
+		// Remove spam like "gcc2_compiled." and remove the existing label for
+		// the function name so it can be reapplied below.
+		SymbolTable symbolTable = program.getSymbolTable();
+		Symbol[] existing_symbols = symbolTable.getSymbols(low);
+		for(Symbol existing_symbol : existing_symbols) {
+			String name = existing_symbol.getName();
+			if(name.equals("__gnu_compiled_cplusplus") || name.equals("gcc2_compiled.") || name.equals(def.name)) {
+				symbolTable.removeSymbolSpecial(existing_symbol);
+			}
+		}
+		
+		// Ghidra will sometimes find the wrong label and use it as a function
+		// name e.g. "gcc2_compiled." so it's important that we set the name
+		// explicitly here.
+		try {
+			function.setName(def.name, SourceType.ANALYSIS);
+		} catch (DuplicateNameException | InvalidInputException e) {
+			log.appendException(e);
+		}
+		function.setComment(sourceFile.path);
+	}
+	
+	private HashSet<String> fillInParameters(Function function, StdumpAST.ImporterState importer,
+			StdumpAST.FunctionDefinition def, StdumpAST.FunctionType type) {
+		HashSet<String> parameter_names = new HashSet<>();
+		if(type.parameters.size() > 0) {
+			ArrayList<Variable> parameters = new ArrayList<>();
+			for(int i = 0; i < type.parameters.size(); i++) {
+				StdumpAST.Variable variable = (StdumpAST.Variable) type.parameters.get(i);
+				DataType parameter_type = StdumpAST.replaceVoidWithUndefined1(variable.type.createType(importer));
+				if(variable.storage.isByReference) {
+					parameter_type = new PointerDataType(parameter_type);
+				}
+				try {
+					parameters.add(new ParameterImpl(variable.name, parameter_type, program));
+				} catch (InvalidInputException e) {
+					log.appendException(e);
+				}
+				parameter_names.add(variable.name);
+			}
+			try {
+				function.replaceParameters(parameters, Function.FunctionUpdateType.DYNAMIC_STORAGE_ALL_PARAMS, true, SourceType.ANALYSIS);
+			} catch(DuplicateNameException | InvalidInputException exception) {
+				log.appendMsg("Failed to setup parameters for " + def.name + ": " + exception.getMessage());
+			}
+		}
+		return parameter_names;
+	}
+	
+	private void markInlinedCode(StdumpAST.FunctionDefinition def, StdumpAST.SourceFile sourceFile) {
+		String path;
+		if(def.relativePath != null) {
+			path = def.relativePath;
+		} else {
+			path = sourceFile.relativePath;
+		}
+		boolean was_inlining = false;
+		for(StdumpAST.SubSourceFile sub : def.subSourceFiles) {
+			boolean is_inlining = !sub.relativePath.equals(path);
+			if(is_inlining && !was_inlining) {
+				setPreComment(toAddr(sub.address), "inlined from " + sub.relativePath);
+			} else if(!is_inlining && was_inlining) {
+				setPreComment(toAddr(sub.address), "end of inlined section");
+			}
+			was_inlining = is_inlining;
+		}
+	}
+	
+	private void fillInLocalVariables(Function function, StdumpAST.ImporterState importer,
+			StdumpAST.FunctionDefinition def, HashSet<String> parameter_names) {
+		// Add local variables.
+		HashMap<String, StdumpAST.Variable> stack_locals = new HashMap<>();
+		for(StdumpAST.Node child : def.locals) {
+			if(child instanceof StdumpAST.Variable && !parameter_names.contains(child.name)) {
+				StdumpAST.Variable src = (StdumpAST.Variable) child;
+				if(src.storageClass != StdumpAST.StorageClass.STATIC && src.storage.type == StdumpAST.VariableStorageType.STACK) {
+					stack_locals.put(src.name, src);
+				}
+			}
+		}
+		for(Map.Entry<String, StdumpAST.Variable> local : stack_locals.entrySet()) {
+			StdumpAST.Variable var = local.getValue();
+			DataType localType = StdumpAST.replaceVoidWithUndefined1(var.type.createType(importer));
+			LocalVariable dest;
+			try {
+				dest = new LocalVariableImpl(var.name, localType, var.storage.stackPointerOffset, program, SourceType.ANALYSIS);
+				function.addLocalVariable(dest, SourceType.ANALYSIS);
+			} catch (DuplicateNameException | InvalidInputException e) {
+				log.appendException(e);
+			}
+		}
+	}
+	
+	public void importGlobalVariables(StdumpAST.ImporterState importer) {
+		AddressSpace space = getAddressFactory().getDefaultAddressSpace();
+		for(StdumpAST.Node file_node : importer.ast.files) {
+			StdumpAST.SourceFile file = (StdumpAST.SourceFile) file_node;
+			for(StdumpAST.Node global_node : file.globals) {
+				StdumpAST.Variable global = (StdumpAST.Variable) global_node;
+				if(global.storage.global_address > -1) {
+					Address address = space.getAddress(global.storage.global_address);
+					DataType type = StdumpAST.replaceVoidWithUndefined1(global.type.createType(importer));
+					try {
+						DataUtilities.createData(currentProgram, address, type, type.getLength(), false, ClearDataMode.CLEAR_ALL_CONFLICT_DATA);
+					} catch (CodeUnitInsertionException e) {
+						log.appendException(e);
+					}
+					try {
+						this.createLabel(address, global.name, true);
+					} catch (Exception e) {
+						log.appendException(e);
+					}
+				}
+			}
+		}
+	}
+	
+	public static byte[] runStdump(String elfPath, TaskMonitor monitor, MessageLog log) throws IOException {
+		String executableName = "stdump" + Platform.CURRENT_PLATFORM.getExecutableExtension();
+		File executable = Application.getOSFile(executableName);
+		String[] command = {
+				executable.getAbsolutePath(),
+				"print_json",
+				elfPath
+		};
+		Process process = Runtime.getRuntime().exec(command);
+		InputStream stdout = process.getInputStream();
+		InputStream stderr = process.getErrorStream();
+		BufferedReader errorReader = new BufferedReader(new InputStreamReader(stderr));
+		boolean isBad = false;
+		while(errorReader.ready()) {
+			log.appendMsg("stdump", errorReader.readLine());
+			isBad = true;
+		}
+		if(!isBad) {
+			return stdout.readAllBytes();
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
@@ -43,7 +43,6 @@ import ghidra.util.task.TaskMonitor;
 public class StabsImporter extends FlatProgramAPI {
 
 	public static class ImportOptions {
-		boolean importDataTypes = true;
 		boolean importFunctions = true;
 		boolean importGlobals = true;
 		boolean markInlinedCode = true;
@@ -157,9 +156,7 @@ public class StabsImporter extends FlatProgramAPI {
 		importer.monitor = monitor;
 		importer.log = log;
 		importer.programTypeManager = program.getDataTypeManager();
-		if(options.importDataTypes) {
-			importDataTypes(importer);
-		}
+		importDataTypes(importer);
 		if(options.importFunctions) {
 			importFunctions(importer, program);
 		}

--- a/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StabsImporter.java
@@ -138,6 +138,10 @@ public class StabsImporter extends FlatProgramAPI {
 
 		cleanupTemporaryFiles();
 		
+		if(monitor.isCancelled()) {
+			return false;
+		}
+		
 		// Parse the JSON file into an AST.
 		monitor.setMessage("STABS - Parsing AST...");
 		StdumpAST.ParsedJsonFile ast;
@@ -145,6 +149,10 @@ public class StabsImporter extends FlatProgramAPI {
 			ast = StdumpParser.readJson(jsonOutput);
 		} catch (FileNotFoundException e) {
 			log.appendException(e);
+			return false;
+		}
+		
+		if(monitor.isCancelled()) {
 			return false;
 		}
 		

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
@@ -89,7 +89,7 @@ public class StdumpAST {
 		
 		public DataType createType(ImporterState importer) {
 			if(isInCreateTypeCall) {
-				importer.log.appendMsg("Bad circular type definition: " + name + "\n");
+				importer.log.appendMsg("Bad circular type definition: " + name);
 				return Undefined1DataType.dataType;
 			}
 			isInCreateTypeCall = true;
@@ -371,14 +371,14 @@ public class StdumpAST {
 				index = importer.typeNameToDeduplicatedTypeIndex.get(type_name);
 			}
 			if(index == null) {
-				importer.log.appendMsg("Type lookup failed: " + type_name + "\n");
+				importer.log.appendMsg("Type lookup failed: " + type_name);
 				return Undefined1DataType.dataType;
 			}
 			DataType type = importer.types.get(index);
 			if(type == null) {
 				Node node = importer.ast.deduplicatedTypes.get(index);
 				if(node instanceof InlineStructOrUnion) {
-					importer.log.appendMsg("Bad type name referencing struct or union: " + type_name + "\n");
+					importer.log.appendMsg("Bad type name referencing struct or union: " + type_name);
 					return Undefined1DataType.dataType;
 				}
 				type = node.createType(importer);

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
@@ -89,7 +89,7 @@ public class StdumpAST {
 		
 		public DataType createType(ImporterState importer) {
 			if(isInCreateTypeCall) {
-				importer.log.appendMsg("Bad circular type definition: " + name);
+				importer.log.appendMsg("STABS", "Bad circular type definition: " + name);
 				return Undefined1DataType.dataType;
 			}
 			isInCreateTypeCall = true;
@@ -99,7 +99,7 @@ public class StdumpAST {
 		}
 		
 		public DataType createTypeImpl(ImporterState importer) {
-			importer.log.appendMsg("createTypeImpl() called on a node that isn't a type.");
+			importer.log.appendMsg("STABS", "createTypeImpl() called on a node that isn't a type.");
 			return Undefined1DataType.dataType;
 		}
 		
@@ -176,7 +176,7 @@ public class StdumpAST {
 				return UnsignedInteger16DataType.dataType;
 			case UNKNOWN_PROBABLY_ARRAY:
 			}
-			importer.log.appendMsg("Bad builtin type created.");
+			importer.log.appendMsg("STABS", "Bad builtin type created.");
 			return Undefined1DataType.dataType;
 		}
 	}
@@ -371,14 +371,14 @@ public class StdumpAST {
 				index = importer.typeNameToDeduplicatedTypeIndex.get(type_name);
 			}
 			if(index == null) {
-				importer.log.appendMsg("Type lookup failed: " + type_name);
+				importer.log.appendMsg("STABS", "Type lookup failed: " + type_name);
 				return Undefined1DataType.dataType;
 			}
 			DataType type = importer.types.get(index);
 			if(type == null) {
 				Node node = importer.ast.deduplicatedTypes.get(index);
 				if(node instanceof InlineStructOrUnion) {
-					importer.log.appendMsg("Bad type name referencing struct or union: " + type_name);
+					importer.log.appendMsg("STABS", "Bad type name referencing struct or union: " + type_name);
 					return Undefined1DataType.dataType;
 				}
 				type = node.createType(importer);

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
@@ -1,0 +1,430 @@
+package ghidra.emotionengine.symboltable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import ghidra.app.services.ConsoleService;
+import ghidra.app.util.importer.MessageLog;
+import ghidra.program.model.data.ArrayDataType;
+import ghidra.program.model.data.CharDataType;
+import ghidra.program.model.data.DataType;
+import ghidra.program.model.data.DataTypeManager;
+import ghidra.program.model.data.EnumDataType;
+import ghidra.program.model.data.FloatDataType;
+import ghidra.program.model.data.Integer16DataType;
+import ghidra.program.model.data.IntegerDataType;
+import ghidra.program.model.data.LongDataType;
+import ghidra.program.model.data.PointerDataType;
+import ghidra.program.model.data.ShortDataType;
+import ghidra.program.model.data.Structure;
+import ghidra.program.model.data.StructureDataType;
+import ghidra.program.model.data.Undefined1DataType;
+import ghidra.program.model.data.Undefined4DataType;
+import ghidra.program.model.data.Union;
+import ghidra.program.model.data.UnionDataType;
+import ghidra.program.model.data.UnsignedCharDataType;
+import ghidra.program.model.data.UnsignedInteger16DataType;
+import ghidra.program.model.data.UnsignedIntegerDataType;
+import ghidra.program.model.data.UnsignedLongDataType;
+import ghidra.program.model.data.UnsignedShortDataType;
+import ghidra.program.model.data.VoidDataType;
+import ghidra.util.task.TaskMonitor;
+
+public class StdumpAST {
+	
+	public static class ParsedJsonFile {
+		ArrayList<Node> files = new ArrayList<Node>();
+		ArrayList<Node> deduplicatedTypes = new ArrayList<Node>();
+	}
+	
+	public static class ImporterState {
+		// Options.
+		boolean markInlinedCode = false;
+		boolean outputLineNumbers = false;
+
+		// Input.
+		ParsedJsonFile ast;
+		
+		// Internal state.
+		ArrayList<DataType> types = new ArrayList<>(); // (data type, size in bytes)
+		ArrayList<HashMap<Integer, Integer>> stabsTypeNumberToDeduplicatedTypeIndex = new ArrayList<>();
+		HashMap<String, Integer> typeNameToDeduplicatedTypeIndex = new HashMap<>();
+		
+		// Ghidra objects.
+		TaskMonitor monitor;
+		MessageLog log;
+		DataTypeManager programTypeManager = null;
+	}
+	
+	public static enum StorageClass {
+		NONE,
+		TYPEDEF,
+		EXTERN,
+		STATIC,
+		AUTO,
+		REGISTER
+	}
+	
+	public static class AddressRange {
+		int low = -1;
+		int high = -1;
+		
+		public boolean valid() {
+			return low > -1;
+		}
+	}
+	
+	public static class Node {
+		String name;
+		StorageClass storageClass = StorageClass.NONE;
+		int relativeOffsetBytes = -1;
+		int absoluteOffsetBytes = -1;
+		int bitfieldOffsetBits = -1;
+		int sizeBits = -1;
+		int firstFile = -1;
+		boolean conflict = false;
+		int stabsTypeNumber = -1;
+		
+		String prefix = ""; // Used for nested structs.
+		boolean isInCreateTypeCall = false; // Prevent infinite recursion.
+		
+		public DataType createType(ImporterState importer) {
+			if(isInCreateTypeCall) {
+				importer.log.appendMsg("Bad circular type definition: " + name + "\n");
+				return Undefined1DataType.dataType;
+			}
+			isInCreateTypeCall = true;
+			DataType type = createTypeImpl(importer);
+			isInCreateTypeCall = false;
+			return type;
+		}
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			return Undefined1DataType.dataType;
+		}
+		
+		String generateName() {
+			if(conflict || name == null || name.isEmpty()) {
+				return prefix + name + "__" + Integer.toString(firstFile) + "_" + Integer.toString(stabsTypeNumber);
+			}
+			return name;
+		}
+	}
+	
+	public static class Array extends Node {
+		Node element_type;
+		int element_count;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			DataType element = replaceVoidWithUndefined1(element_type.createType(importer));
+			return new ArrayDataType(element, element_count, element.getLength());
+		}
+	}
+	
+	public static class BitField extends Node {
+		Node underlying_type;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			return underlying_type.createType(importer);
+		}
+	}
+	
+	public static enum BuiltInClass {
+		VOID,
+		UNSIGNED_8, SIGNED_8, UNQUALIFIED_8, BOOL_8,
+		UNSIGNED_16, SIGNED_16,
+		UNSIGNED_32, SIGNED_32, FLOAT_32,
+		UNSIGNED_64, SIGNED_64, FLOAT_64,
+		UNSIGNED_128, SIGNED_128, UNQUALIFIED_128, FLOAT_128,
+		UNKNOWN_PROBABLY_ARRAY
+	}
+	
+	public static class BuiltIn extends Node {
+		BuiltInClass builtin_class;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			switch(builtin_class) {
+			case VOID:
+				return VoidDataType.dataType;
+			case UNSIGNED_8:
+				return UnsignedCharDataType.dataType;
+			case SIGNED_8:
+			case UNQUALIFIED_8:
+			case BOOL_8:
+				return CharDataType.dataType;
+			case UNSIGNED_16:
+				return ShortDataType.dataType;
+			case SIGNED_16:
+				return UnsignedShortDataType.dataType;
+			case UNSIGNED_32:
+				return UnsignedIntegerDataType.dataType;
+			case SIGNED_32:
+				return IntegerDataType.dataType;
+			case FLOAT_32:
+				return FloatDataType.dataType;
+			case UNSIGNED_64:
+				return UnsignedLongDataType.dataType;
+			case SIGNED_64:
+			case FLOAT_64:
+				return LongDataType.dataType;
+			case UNSIGNED_128:
+				return UnsignedInteger16DataType.dataType;
+			case SIGNED_128:
+				return Integer16DataType.dataType;
+			case UNQUALIFIED_128:
+			case FLOAT_128:
+				return UnsignedInteger16DataType.dataType;
+			case UNKNOWN_PROBABLY_ARRAY:
+			}
+			importer.log.appendMsg("Bad builtin type created.");
+			return Undefined1DataType.dataType;
+		}
+	}
+	
+	public static class LineNumberPair {
+		int address;
+		int lineNumber;
+	}
+	
+	public static class SubSourceFile {
+		int address;
+		String relativePath;
+	}
+	
+	public static class FunctionDefinition extends Node {
+		AddressRange addressRange = new AddressRange();
+		String relativePath;
+		Node type;
+		ArrayList<Variable> locals = new ArrayList<>();
+		ArrayList<LineNumberPair> lineNumbers = new ArrayList<>();
+		ArrayList<SubSourceFile> subSourceFiles = new ArrayList<>();
+	}
+	
+	public static class FunctionType extends Node {
+		Node returnType = null;
+		ArrayList<Node> parameters = new ArrayList<Node>();
+		int vtableIndex = -1;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			importer.log.appendMsg("Bad function type created.");
+			return Undefined1DataType.dataType;
+		}
+	}
+	
+	public static class EnumConstant {
+		int value;
+		String name;
+	}
+	
+	public static class InlineEnum extends Node {
+		ArrayList<EnumConstant> constants = new ArrayList<EnumConstant>();
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			EnumDataType type = new EnumDataType(generateName(), 4);
+			for(EnumConstant constant : constants) {
+				type.add(constant.name, constant.value);
+			}
+			return type;
+		}
+	}
+	
+	public static class BaseClass {
+		int offset;
+		Node type;
+	}
+	
+	public static class InlineStructOrUnion extends Node {
+		boolean isStruct;
+		ArrayList<BaseClass> baseClasses = new ArrayList<BaseClass>();
+		ArrayList<Node> fields = new ArrayList<Node>();
+		ArrayList<Node> memberFunctions = new ArrayList<Node>();
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			DataType result = create_empty(importer);
+			fill(result, importer);
+			return result;
+		}
+		
+		public DataType create_empty(ImporterState importer) {
+			String typeName = generateName();
+			int sizeBytes = sizeBits / 8;
+			DataType type;
+			if(isStruct) {
+				type = new StructureDataType(typeName, sizeBytes, importer.programTypeManager);
+			} else {
+				type = new UnionDataType(typeName);
+			}
+			return type;
+		}
+		
+		public void fill(DataType dest, ImporterState importer) {
+			if(isStruct) {
+				Structure type = (Structure) dest;
+				for(int i = 0; i < baseClasses.size(); i++) {
+					BaseClass baseClass = baseClasses.get(i);
+					DataType baseType = replaceVoidWithUndefined1(baseClass.type.createType(importer));
+					boolean isBeyondEnd = baseClass.offset + baseType.getLength() > sizeBits / 8;
+					if(!isBeyondEnd && baseClass.offset > -1) {
+						type.replaceAtOffset(baseClass.offset, baseType, baseType.getLength(), "base_class_" + Integer.toString(i), "");
+					}
+				}
+				for(Node node : fields) {
+					if(node.storageClass != StorageClass.STATIC) {
+						// Currently we don't try to import bit fields.
+						boolean isBitfield = node instanceof BitField;
+						DataType field = null;
+						if(node.name != null && node.name.equals("__vtable")) {
+							field = new PointerDataType(create_vtable(importer));
+						} else {
+							node.prefix += name + "__";
+							field = replaceVoidWithUndefined1(node.createType(importer));
+						}
+						boolean isBeyondEnd = node.relativeOffsetBytes + field.getLength() > sizeBits / 8;
+						if(!isBitfield && !isBeyondEnd) {
+							type.replaceAtOffset(node.relativeOffsetBytes, field, field.getLength(), node.name, "");
+						}
+					}
+				}
+			} else {
+				Union type = (Union) dest;
+				for(Node node : fields) {
+					if(node.storageClass != StorageClass.STATIC) {
+						DataType field = replaceVoidWithUndefined1(node.createType(importer));
+						type.add(field, field.getLength(), node.name, "");
+					}
+				}
+			}
+		}
+		
+		public DataType create_vtable(ImporterState importer) {
+			StructureDataType vtable = new StructureDataType(generateName() + "__vtable", 0, importer.programTypeManager);
+			for(Node node : memberFunctions) {
+				if(node instanceof FunctionType) {
+					FunctionType function = (FunctionType) node;
+					if(function.vtableIndex > -1) {
+						int end = (function.vtableIndex + 1) * 4;
+						if(end > vtable.getLength()) {
+							vtable.growStructure(end - vtable.getLength());
+						}
+						try {
+							vtable.replaceAtOffset(function.vtableIndex * 4, PointerDataType.dataType, 4, function.name, "");
+						} catch(IllegalArgumentException e) {}
+					}
+				}
+			}
+			return vtable;
+		}
+	}
+	
+	public static class Pointer extends Node {
+		Node valueType;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			return new PointerDataType(valueType.createType(importer));
+		}
+	}
+	
+	public static class PointerToDataMember extends Node {
+		public DataType createTypeImpl(ImporterState importer) {
+			return Undefined4DataType.dataType;
+		}
+	}
+	
+	public static class Reference extends Node {
+		Node valueType;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			return new PointerDataType(valueType.createType(importer));
+		}
+	}
+	
+	public static class SourceFile extends Node {
+		String path;
+		String relativePath;
+		int text_address;
+		ArrayList<Node> types = new ArrayList<Node>();
+		ArrayList<Node> functions = new ArrayList<Node>();
+		ArrayList<Node> globals = new ArrayList<Node>();
+		HashMap<Integer, Integer> stabsTypeNumberToDeduplicatedTypeIndex = new HashMap<Integer, Integer>();
+	}
+	
+	public static class TypeName extends Node {
+		String type_name;
+		int referencedFileIndex = -1;
+		int referencedStabsTypeNumber = -1;
+		
+		public DataType createTypeImpl(ImporterState importer) {
+			if(type_name.equals("void")) {
+				return VoidDataType.dataType;
+			}
+			Integer index = null;
+			if(referencedFileIndex > -1 && referencedStabsTypeNumber > -1) {
+				// Lookup the type by its STABS type number. This path
+				// ensures that the correct type is found even if multiple
+				// types have the same name.
+				HashMap<Integer, Integer> indexLookup = importer.stabsTypeNumberToDeduplicatedTypeIndex.get(referencedFileIndex);
+				index = indexLookup.get(referencedStabsTypeNumber);
+			}
+			if(index == null) {
+				// For STABS cross references, no type number is provided,
+				// so we must lookup the type by name instead. This is
+				// riskier but I think it's the best we can really do.
+				index = importer.typeNameToDeduplicatedTypeIndex.get(type_name);
+			}
+			if(index == null) {
+				importer.log.appendMsg("Type lookup failed: " + type_name + "\n");
+				return Undefined1DataType.dataType;
+			}
+			DataType type = importer.types.get(index);
+			if(type == null) {
+				Node node = importer.ast.deduplicatedTypes.get(index);
+				if(node instanceof InlineStructOrUnion) {
+					importer.log.appendMsg("Bad type name referencing struct or union: " + type_name + "\n");
+					return Undefined1DataType.dataType;
+				}
+				type = node.createType(importer);
+				importer.types.set(index, type);
+			}
+			return type;
+		}
+	}
+	
+	public static enum VariableClass {
+		GLOBAL,
+		LOCAL,
+		PARAMETER
+	}
+	
+	public static enum VariableStorageType {
+		GLOBAL,
+		REGISTER,
+		STACK
+	}
+	
+	public static class VariableStorage {
+		VariableStorageType type;
+		int global_address = -1;
+		String register;
+		String registerClass;
+		int dbxRegisterNumber = -1;
+		int registerIndexRelative = -1;
+		boolean isByReference = false;
+		int stackPointerOffset = -1;
+	}
+	
+	public static class Variable extends Node {
+		VariableClass variable_class;
+		VariableStorage storage;
+		int blockLow = -1;
+		int blockHigh = -1;
+		Node type;
+	}
+	
+	public static DataType replaceVoidWithUndefined1(DataType type) {
+		if(type.isEquivalent(VoidDataType.dataType)) {
+			return Undefined1DataType.dataType;
+		}
+		return type;
+	}
+	
+}

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
@@ -3,7 +3,6 @@ package ghidra.emotionengine.symboltable;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import ghidra.app.services.ConsoleService;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.program.model.data.ArrayDataType;
 import ghidra.program.model.data.CharDataType;
@@ -100,6 +99,7 @@ public class StdumpAST {
 		}
 		
 		public DataType createTypeImpl(ImporterState importer) {
+			importer.log.appendMsg("createTypeImpl() called on a node that isn't a type.");
 			return Undefined1DataType.dataType;
 		}
 		
@@ -206,7 +206,6 @@ public class StdumpAST {
 		int vtableIndex = -1;
 		
 		public DataType createTypeImpl(ImporterState importer) {
-			importer.log.appendMsg("Bad function type created.");
 			return Undefined1DataType.dataType;
 		}
 	}

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpAST.java
@@ -227,14 +227,9 @@ public class StdumpAST {
 		}
 	}
 	
-	public static class BaseClass {
-		int offset;
-		Node type;
-	}
-	
 	public static class InlineStructOrUnion extends Node {
 		boolean isStruct;
-		ArrayList<BaseClass> baseClasses = new ArrayList<BaseClass>();
+		ArrayList<Node> baseClasses = new ArrayList<Node>();
 		ArrayList<Node> fields = new ArrayList<Node>();
 		ArrayList<Node> memberFunctions = new ArrayList<Node>();
 		
@@ -260,11 +255,11 @@ public class StdumpAST {
 			if(isStruct) {
 				Structure type = (Structure) dest;
 				for(int i = 0; i < baseClasses.size(); i++) {
-					BaseClass baseClass = baseClasses.get(i);
-					DataType baseType = replaceVoidWithUndefined1(baseClass.type.createType(importer));
-					boolean isBeyondEnd = baseClass.offset + baseType.getLength() > sizeBits / 8;
-					if(!isBeyondEnd && baseClass.offset > -1) {
-						type.replaceAtOffset(baseClass.offset, baseType, baseType.getLength(), "base_class_" + Integer.toString(i), "");
+					Node baseClass = baseClasses.get(i);
+					DataType baseType = replaceVoidWithUndefined1(baseClass.createType(importer));
+					boolean isBeyondEnd = baseClass.absoluteOffsetBytes + baseType.getLength() > sizeBits / 8;
+					if(!isBeyondEnd && baseClass.absoluteOffsetBytes > -1) {
+						type.replaceAtOffset(baseClass.absoluteOffsetBytes, baseType, baseType.getLength(), "base_class_" + Integer.toString(i), "");
 					}
 				}
 				for(Node node : fields) {

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpParser.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpParser.java
@@ -1,0 +1,308 @@
+package ghidra.emotionengine.symboltable;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.stream.JsonReader;
+
+public class StdumpParser {
+	public static final String SUPPORTED_STDUMP_VERSION = "v1.0";
+	public static final int SUPPORTED_FORMAT_VERSION = 6;
+	
+	public static StdumpAST.ParsedJsonFile readJson(byte[] json) throws FileNotFoundException {
+		JsonReader reader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(json)));
+		GsonBuilder gsonBuilder = new GsonBuilder();
+		gsonBuilder.registerTypeAdapter(StdumpAST.ParsedJsonFile.class, new JsonFileDeserializer());
+		gsonBuilder.registerTypeAdapter(StdumpAST.Node.class, new NodeDeserializer());
+		Gson gson = gsonBuilder.create();
+		return gson.fromJson(reader, StdumpAST.ParsedJsonFile.class);
+	}
+	
+	private static class JsonFileDeserializer implements JsonDeserializer<StdumpAST.ParsedJsonFile> {
+		@Override
+		public StdumpAST.ParsedJsonFile deserialize(JsonElement element, Type type, JsonDeserializationContext context)
+				throws JsonParseException {
+			StdumpAST.ParsedJsonFile result = new StdumpAST.ParsedJsonFile();
+			JsonObject object = element.getAsJsonObject();
+			if(!object.has("version")) {
+				throw new JsonParseException("JSON file has missing version number field.");
+			}
+			int version = object.get("version").getAsInt();
+			if(version != SUPPORTED_FORMAT_VERSION) {
+				String versionInfo = Integer.toString(version) + ", should be " + Integer.toString(SUPPORTED_FORMAT_VERSION);
+				throw new JsonParseException("JSON file is in an unsupported format (version is " + versionInfo + "). You're probably using the wrong version of stdump!");
+			}
+			JsonArray files = object.get("files").getAsJsonArray();
+			for(JsonElement fileNode : files) {
+				result.files.add(context.deserialize(fileNode, StdumpAST.Node.class));
+			}
+			JsonArray deduplicatedTypes = object.get("deduplicated_types").getAsJsonArray();
+			for(JsonElement type_node : deduplicatedTypes) {
+				result.deduplicatedTypes.add(context.deserialize(type_node, StdumpAST.Node.class));
+			}
+			return result;
+		}
+	}
+	
+	private static class NodeDeserializer implements JsonDeserializer<StdumpAST.Node> {
+		@Override
+		public StdumpAST.Node deserialize(JsonElement element, Type type, JsonDeserializationContext context)
+				throws JsonParseException {
+			JsonObject object = element.getAsJsonObject();
+			String descriptor = object.get("descriptor").getAsString();
+			StdumpAST.Node node;
+			if(descriptor.equals("array")) {
+				StdumpAST.Array array = new StdumpAST.Array();
+				array.element_type = context.deserialize(object.get("element_type"), StdumpAST.Node.class);
+				array.element_count = object.get("element_count").getAsInt();
+				node = array;
+			} else if(descriptor.equals("bitfield")) {
+				StdumpAST.BitField bitfield = new StdumpAST.BitField();
+				bitfield.underlying_type = context.deserialize(object.get("underlying_type"), StdumpAST.Node.class);
+				node = bitfield;
+			} else if(descriptor.equals("builtin")) {
+				StdumpAST.BuiltIn builtin = new StdumpAST.BuiltIn();
+				String builtin_class = object.get("class").getAsString();
+				builtin.builtin_class = readBuiltInClass(builtin, builtin_class);
+				node = builtin;
+			} else if(descriptor.equals("function_definition")) {
+				StdumpAST.FunctionDefinition function = new StdumpAST.FunctionDefinition();
+				if(object.has("address_range")) {
+					function.addressRange = readAddressRange(object.get("address_range").getAsJsonObject());
+				}
+				if(object.has("relative_path")) {
+					function.relativePath = object.get("relative_path").getAsString();
+				}
+				function.type = context.deserialize(object.get("type"), StdumpAST.Node.class);
+				for(JsonElement local : object.get("locals").getAsJsonArray()) {
+					function.locals.add(context.deserialize(local.getAsJsonObject(), StdumpAST.Node.class));
+				}
+				for(JsonElement pair : object.get("line_numbers").getAsJsonArray()) {
+					JsonArray src = pair.getAsJsonArray();
+					StdumpAST.LineNumberPair dest = new StdumpAST.LineNumberPair();
+					dest.address = src.get(0).getAsInt();
+					dest.lineNumber = src.get(1).getAsInt();
+					function.lineNumbers.add(dest);
+				}
+				for(JsonElement sub : object.get("sub_source_files").getAsJsonArray()) {
+					JsonObject src = sub.getAsJsonObject();
+					StdumpAST.SubSourceFile dest = new StdumpAST.SubSourceFile();
+					dest.address = src.get("address").getAsInt();
+					dest.relativePath = src.get("path").getAsString();
+					function.subSourceFiles.add(dest);
+				}
+				node = function;
+			} else if(descriptor.equals("function_type")) {
+				StdumpAST.FunctionType function_type = new StdumpAST.FunctionType();
+				if(object.has("return_type")) {
+					function_type.returnType = context.deserialize(object.get("return_type"), StdumpAST.Node.class);
+				}
+				if(object.has("parameters")) {
+					for(JsonElement parameter : object.get("parameters").getAsJsonArray()) {
+						function_type.parameters.add(context.deserialize(parameter, StdumpAST.Node.class));
+					}
+				}
+				function_type.vtableIndex = object.get("vtable_index").getAsInt();
+				node = function_type;
+			} else if(descriptor.equals("enum")) {
+				StdumpAST.InlineEnum inline_enum = new StdumpAST.InlineEnum();
+				for(JsonElement src : object.get("constants").getAsJsonArray()) {
+					StdumpAST.EnumConstant dest = new StdumpAST.EnumConstant();
+					JsonObject src_object = src.getAsJsonObject();
+					dest.value = src_object.get("value").getAsInt();
+					dest.name = src_object.get("name").getAsString();
+					inline_enum.constants.add(dest);
+				}
+				node = inline_enum;
+			} else if(descriptor.equals("struct") || descriptor.equals("union")) {
+				StdumpAST.InlineStructOrUnion struct_or_union = new StdumpAST.InlineStructOrUnion();
+				struct_or_union.isStruct = descriptor.equals("struct");
+				if(struct_or_union.isStruct) {
+					for(JsonElement base_class : object.get("base_classes").getAsJsonArray()) {
+						StdumpAST.BaseClass dest = new StdumpAST.BaseClass();
+						JsonObject src = base_class.getAsJsonObject();
+						dest.offset = src.get("offset").getAsInt();
+						dest.type = context.deserialize(src.get("type"), StdumpAST.Node.class);
+						struct_or_union.baseClasses.add(dest);
+					}
+				}
+				for(JsonElement field : object.get("fields").getAsJsonArray()) {
+					struct_or_union.fields.add(context.deserialize(field, StdumpAST.Node.class));
+				}
+				for(JsonElement member_function : object.get("member_functions").getAsJsonArray()) {
+					struct_or_union.memberFunctions.add(context.deserialize(member_function, StdumpAST.Node.class));
+				}
+				node = struct_or_union;
+			} else if(descriptor.equals("pointer")) {
+				StdumpAST.Pointer pointer = new StdumpAST.Pointer();
+				pointer.valueType = context.deserialize(object.get("value_type"), StdumpAST.Node.class);
+				node = pointer;
+			} else if(descriptor.equals("pointer_to_data_member")) {
+				node = new StdumpAST.PointerToDataMember();
+			} else if(descriptor.equals("reference")) {
+				StdumpAST.Reference reference = new StdumpAST.Reference();
+				reference.valueType = context.deserialize(object.get("value_type"), StdumpAST.Node.class);
+				node = reference;
+			} else if(descriptor.equals("source_file")) {
+				StdumpAST.SourceFile source_file = new StdumpAST.SourceFile();
+				source_file.path = object.get("path").getAsString();
+				source_file.relativePath = object.get("relative_path").getAsString();
+				source_file.text_address = object.get("text_address").getAsInt();
+				for(JsonElement type_object : object.get("types").getAsJsonArray()) {
+					source_file.types.add(context.deserialize(type_object, StdumpAST.Node.class));
+				}
+				for(JsonElement function_object : object.get("functions").getAsJsonArray()) {
+					source_file.functions.add(context.deserialize(function_object, StdumpAST.Node.class));
+				}
+				for(JsonElement global_object : object.get("globals").getAsJsonArray()) {
+					source_file.globals.add(context.deserialize(global_object, StdumpAST.Node.class));
+				}
+				JsonElement stabs_type_number_to_deduplicated_type_index = object.get("stabs_type_number_to_deduplicated_type_index");
+				for(Map.Entry<String, JsonElement> entry : stabs_type_number_to_deduplicated_type_index.getAsJsonObject().entrySet()) {
+					int stabs_type_number = Integer.parseInt(entry.getKey());
+					int type_index = entry.getValue().getAsInt();
+					source_file.stabsTypeNumberToDeduplicatedTypeIndex.put(stabs_type_number, type_index);
+				}
+				node = source_file;
+			} else if(descriptor.equals("type_name")) {
+				StdumpAST.TypeName type_name = new StdumpAST.TypeName();
+				type_name.type_name = object.get("type_name").getAsString();
+				if(object.has("referenced_file_index")) {
+					type_name.referencedFileIndex = object.get("referenced_file_index").getAsInt();
+				}
+				if(object.has("referenced_stabs_type_number")) {
+					type_name.referencedStabsTypeNumber = object.get("referenced_stabs_type_number").getAsInt();
+				}
+				node = type_name;
+			} else if(descriptor.equals("variable")) {
+				StdumpAST.Variable variable = new StdumpAST.Variable();
+				String variable_class = object.get("class").getAsString();
+				if(variable_class.equals("global")) {
+					variable.variable_class = StdumpAST.VariableClass.GLOBAL;
+				} else if(variable_class.equals("local")) {
+					variable.variable_class = StdumpAST.VariableClass.LOCAL;
+				} else if(variable_class.equals("parameter")) {
+					variable.variable_class = StdumpAST.VariableClass.PARAMETER;
+				} else {
+					throw new JsonParseException("Bad variable class: " + variable_class);
+				}
+				variable.storage = readVariableStorage(object.get("storage").getAsJsonObject());
+				if(object.has("block_low")) {
+					variable.blockLow = object.get("block_low").getAsInt();
+				}
+				if(object.has("block_high")) {
+					variable.blockHigh = object.get("block_high").getAsInt();
+				}
+				variable.type = context.deserialize(object.get("type"), StdumpAST.Node.class);
+				node = variable;
+			} else {
+				throw new JsonParseException("Bad node descriptor: " + descriptor);
+			}
+			readCommon(node, object);
+			return node;
+		}
+		
+		private void readCommon(StdumpAST.Node dest, JsonObject src) throws JsonParseException {
+			if(src.has("name")) {
+				dest.name = src.get("name").getAsString();
+			}
+			if(src.has("storage_class")) {
+				String storage_class = src.get("storage_class").getAsString();
+				if(storage_class.equals("typedef")) {
+					dest.storageClass = StdumpAST.StorageClass.TYPEDEF;
+				} else if(storage_class.equals("extern")) {
+					dest.storageClass = StdumpAST.StorageClass.EXTERN;
+				} else if(storage_class.equals("static")) {
+					dest.storageClass = StdumpAST.StorageClass.STATIC;
+				} else if(storage_class.equals("auto")) {
+					dest.storageClass = StdumpAST.StorageClass.AUTO;
+				} else if(storage_class.equals("register")) {
+					dest.storageClass = StdumpAST.StorageClass.REGISTER;
+				}
+			}
+			if(src.has("relative_offset_bytes")) {
+				dest.relativeOffsetBytes = src.get("relative_offset_bytes").getAsInt();
+			}
+			if(src.has("absolute_offset_bytes")) {
+				dest.absoluteOffsetBytes = src.get("absolute_offset_bytes").getAsInt();
+			}
+			if(src.has("bitfield_offset_bits")) {
+				dest.bitfieldOffsetBits = src.get("bitfield_offset_bits").getAsInt();
+			}
+			if(src.has("size_bits")) {
+				dest.sizeBits = src.get("size_bits").getAsInt();
+			}
+			if(src.has("files")) {
+				dest.firstFile = src.get("files").getAsJsonArray().get(0).getAsInt();
+			}
+			if(src.has("conflict")) {
+				dest.conflict = src.get("conflict").getAsBoolean();
+			}
+			if(src.has("stabs_type_number")) {
+				dest.stabsTypeNumber = src.get("stabs_type_number").getAsInt();
+			}
+		}
+		
+		private StdumpAST.BuiltInClass readBuiltInClass(StdumpAST.BuiltIn builtin, String builtin_class) throws JsonParseException {
+			if(builtin_class.equals("void")) { return StdumpAST.BuiltInClass.VOID; }
+			else if(builtin_class.equals("8-bit unsigned integer")) { return StdumpAST.BuiltInClass.UNSIGNED_8; }
+			else if(builtin_class.equals("8-bit signed integer")) { return StdumpAST.BuiltInClass.SIGNED_8; }
+			else if(builtin_class.equals("8-bit integer")) { return StdumpAST.BuiltInClass.UNQUALIFIED_8; }
+			else if(builtin_class.equals("8-bit boolean")) { return StdumpAST.BuiltInClass.BOOL_8; }
+			else if(builtin_class.equals("16-bit unsigned integer")) { return StdumpAST.BuiltInClass.UNSIGNED_16; }
+			else if(builtin_class.equals("16-bit signed integer")) { return StdumpAST.BuiltInClass.SIGNED_16; }
+			else if(builtin_class.equals("32-bit unsigned integer")) { return StdumpAST.BuiltInClass.UNSIGNED_32; }
+			else if(builtin_class.equals("32-bit signed integer")) { return StdumpAST.BuiltInClass.SIGNED_32; }
+			else if(builtin_class.equals("32-bit floating point")) { return StdumpAST.BuiltInClass.FLOAT_32; }
+			else if(builtin_class.equals("64-bit unsigned integer")) { return StdumpAST.BuiltInClass.UNSIGNED_64; }
+			else if(builtin_class.equals("64-bit signed integer")) { return StdumpAST.BuiltInClass.SIGNED_64; }
+			else if(builtin_class.equals("64-bit floating point")) { return StdumpAST.BuiltInClass.FLOAT_64; }
+			else if(builtin_class.equals("128-bit unsigned integer")) { return StdumpAST.BuiltInClass.UNSIGNED_128; }
+			else if(builtin_class.equals("128-bit signed integer")) { return StdumpAST.BuiltInClass.SIGNED_128; }
+			else if(builtin_class.equals("128-bit integer")) { return StdumpAST.BuiltInClass.UNQUALIFIED_128; }
+			else if(builtin_class.equals("128-bit floating point")) { return StdumpAST.BuiltInClass.FLOAT_128; }
+			else { throw new JsonParseException("Bad builtin class."); }
+		}
+		
+		private StdumpAST.VariableStorage readVariableStorage(JsonObject src) {
+			StdumpAST.VariableStorage dest = new StdumpAST.VariableStorage();
+			String type = src.get("type").getAsString();
+			if(type.equals("global")) {
+				dest.type = StdumpAST.VariableStorageType.GLOBAL;
+				dest.global_address = src.get("global_address").getAsInt();
+			} else if(type.equals("register")) {
+				dest.type = StdumpAST.VariableStorageType.REGISTER;
+				dest.register = src.get("register").getAsString();
+				dest.registerClass = src.get("register_class").getAsString();
+				dest.dbxRegisterNumber = src.get("dbx_register_number").getAsInt();
+				dest.registerIndexRelative = src.get("register_index").getAsInt();
+				dest.isByReference = src.get("is_by_reference").getAsBoolean();
+			} else if(type.equals("stack")) {
+				dest.type = StdumpAST.VariableStorageType.STACK;
+				dest.stackPointerOffset = src.get("stack_offset").getAsInt();
+			} else {
+				throw new JsonParseException("Bad variable storage type: " + type);
+			}
+			return dest;
+		}
+		
+		private StdumpAST.AddressRange readAddressRange(JsonObject src) {
+			StdumpAST.AddressRange dest = new StdumpAST.AddressRange();
+			dest.low = src.get("low").getAsInt();
+			dest.high = src.get("high").getAsInt();
+			return dest;
+		}
+	}
+	
+}

--- a/src/main/java/ghidra/emotionengine/symboltable/StdumpParser.java
+++ b/src/main/java/ghidra/emotionengine/symboltable/StdumpParser.java
@@ -18,7 +18,7 @@ import com.google.gson.stream.JsonReader;
 
 public class StdumpParser {
 	public static final String SUPPORTED_STDUMP_VERSION = "v1.0";
-	public static final int SUPPORTED_FORMAT_VERSION = 6;
+	public static final int SUPPORTED_FORMAT_VERSION = 7;
 	
 	public static StdumpAST.ParsedJsonFile readJson(byte[] json) throws FileNotFoundException {
 		JsonReader reader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(json)));
@@ -130,11 +130,7 @@ public class StdumpParser {
 				struct_or_union.isStruct = descriptor.equals("struct");
 				if(struct_or_union.isStruct) {
 					for(JsonElement base_class : object.get("base_classes").getAsJsonArray()) {
-						StdumpAST.BaseClass dest = new StdumpAST.BaseClass();
-						JsonObject src = base_class.getAsJsonObject();
-						dest.offset = src.get("offset").getAsInt();
-						dest.type = context.deserialize(src.get("type"), StdumpAST.Node.class);
-						struct_or_union.baseClasses.add(dest);
+						struct_or_union.baseClasses.add(context.deserialize(base_class, StdumpAST.Node.class));
 					}
 				}
 				for(JsonElement field : object.get("fields").getAsJsonArray()) {


### PR DESCRIPTION
This will extract data types, functions and global variables from executable files containing a .mdebug section automatically during auto analysis. This is based on [ccc](https://github.com/chaoticgd/ccc) which I've been working heavily on for the last few months.

To use it from source you'll need to build the extension yourself using Gradle and you'll need to provide your own stdump executable file. When the next release is put out this will all be done for you so it should all just work.