### PR TITLE
Enable automatic unstable CI builds again

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,9 +1,9 @@
-name: Publish releases
+name: Publish unstable builds
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 jobs:
   build_and_publish:
@@ -33,6 +33,6 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*ghidra-emotionengine-reloaded.zip
-          tag: ${{ github.ref }}
+          tag: "unstable"
           overwrite: true
           file_glob: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This extension is based on the original [ghidra-emotionengine](https://github.co
 
 ## Installation
 
-Precompiled packages are available on the [releases](https://github.com/chaoticgd/ghidra-emotionengine-reloaded/releases) page. To install the package, follow the instructions in the [Ghidra documentation](https://ghidra-sre.org/InstallationGuide.html#Extensions).
+Release builds are available on the [releases](https://github.com/chaoticgd/ghidra-emotionengine-reloaded/releases) page. Unstable builds, generated whenever there is a push to the main branch, are available [here](https://github.com/chaoticgd/ghidra-emotionengine-reloaded/releases/tag/unstable). To install the package, follow the instructions in the [Ghidra documentation](https://ghidra-sre.org/InstallationGuide.html#Extensions).
 
 
 ## Building


### PR DESCRIPTION
This time they'll only happen whenever there's a push to the main branch instead of every single day.