### PR TITLE
Make the PCSX2 save state importer skip over overlay blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v2.1.6
 
-- Fixed an issue with the PCSX2 save state importer.
+- The PCSX2 save state importer will no longer crash when encountering certain overlay sections.
 
 # v2.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v2.1.6
+
+- Fixed an issue with the PCSX2 save state importer.
+
 # v2.1.5
 
 - Added support for Ghidra 10.3.

--- a/ghidra_scripts/PCSX2SaveStateImporter.java
+++ b/ghidra_scripts/PCSX2SaveStateImporter.java
@@ -63,10 +63,9 @@ public class PCSX2SaveStateImporter extends GhidraScript {
         monitor.setMessage("Loading Main Memory...");
         for (MemoryBlock block : blocks) {
             monitor.checkCanceled();
-            if (block.getEnd().getOffset() > maxAddress) {
-                if (block.getEnd().getOffset() < MAX_ADDRESS) {
-                    maxAddress = block.getEnd().getOffset();
-                }
+            long end = block.getEnd().getOffset();
+            if (end > maxAddress && end < MAX_ADDRESS && !block.isOverlay()) {
+                maxAddress = block.getEnd().getOffset();
             }
             if (block.isWrite() && !block.isExecute()) {
                 // only load and replace writable, non-executable memory blocks


### PR DESCRIPTION
Fixes #27