### PR TITLE
stabs: Implement support for bit fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ data/languages/*.sla
 hs_err_pid*
 
 # IDE/ant/gradle
+.idea
 .settings
 .ant*
 .gradle
@@ -42,7 +43,13 @@ hs_err_pid*
 # vscode generated files
 *.vscode
 
+# IntelliJ Gradle auto-downloaded files
+/gradle/
+gradlew
+gradlew.bat
+
 /bin/
 /os/linux_x86_64/
 /os/mac_x86_64/
 /os/win_x86_64/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.1.11
 
 - stabs: Built-ins and typedefs are now imported and used instead of their underlying type.
+- stabs: Bitfields are now imported instead of being replaced with `undefined` bytes.
 - stabs: Anonymous return types, parameter types, local variable types and global variable types are now given more useful names.
 
 ## v2.1.10


### PR DESCRIPTION
Currently, bit fields are not imported into Ghidra even if they exist in the STABS data.

```c
struct _hierhead { // 0x4
	/* 0x0:0 */ unsigned int opcode : 6;
	/* 0x0:6 */ unsigned int isRelocated : 1;
	/* 0x0:7 */ unsigned int id2 : 11;
	/* 0x2:2 */ unsigned int id1 : 14;
};
```

![image](https://github.com/chaoticgd/ghidra-emotionengine-reloaded/assets/27463243/7a05605f-0eec-4c22-a312-c0c4841e4737)

This PR implements support for bit fields to be imported.

![image](https://github.com/chaoticgd/ghidra-emotionengine-reloaded/assets/27463243/949523b2-f550-4ae1-8e32-c5a09df6c9a0)

