### PR TITLE
Show the syscall number in the decompilation instead of the break code

### DIFF
--- a/data/languages/mips.sinc
+++ b/data/languages/mips.sinc
@@ -627,9 +627,8 @@ define pcodeop SYNC;
 }
 
 # 0000 00cc cccc cccc cccc cccc cc00 1100
-:syscall                        		is prime=0 & fct=12 & breakcode {
-    tmp:4=breakcode;
-    syscall(tmp);
+:syscall breakcode              		is prime=0 & fct=12 & breakcode {
+    syscall(v1);
 }
 
 # 0000 00ss ssst tttt cccc cccc cc11 0100


### PR DESCRIPTION
Now the break code is shown in the disassembly instead.