### PR TITLE
Fix typo in COP0 cache instruction definition

### DIFF
--- a/data/languages/cop0.sinc
+++ b/data/languages/cop0.sinc
@@ -60,7 +60,7 @@ attach names op [
     BPR _ BHINBT IHIN
     BFH _ IFL _
     DXLTG DXLDT DXSTG DXSDT
-    GXWBIN _ DXIN _
+    DXWBIN _ DXIN _
     DHWBIN _ DHIN _
     DHWOIN _ _ _
 ];


### PR DESCRIPTION
Fixes #72.