### PR TITLE
Give the EE_ElfRelocationHandler class priority over the MIPS one

### DIFF
--- a/src/main/java/ghidra/emotionengine/relocation/EE_ElfRelocationHandler.java
+++ b/src/main/java/ghidra/emotionengine/relocation/EE_ElfRelocationHandler.java
@@ -27,8 +27,10 @@ import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.*;
 import ghidra.program.model.reloc.Relocation.Status;
 import ghidra.program.model.reloc.RelocationResult;
+import ghidra.util.classfinder.ExtensionPointProperties;
 import ghidra.util.exception.AssertException;
 
+@ExtensionPointProperties(priority = 2)
 public class EE_ElfRelocationHandler
 		extends AbstractElfRelocationHandler<EE_ElfRelocationType, EE_ElfRelocationContext> {
 


### PR DESCRIPTION
Rather embarassingly, the recent relocation refactor made the class searcher pick the built-in MIPS one over the EE one.