### PR TITLE
Prevent duplicate GitHub Actions runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   test:


### PR DESCRIPTION
Previously the test action would run twice for each Ghidra version when pushing and making a PR.