### PR TITLE
Disable the DvpOverlayTable class to fix the symbol tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.30
+
+- Disabled the DvpOverlayTable class as a temporary measure to fix the symbol tree.
+
 ## v2.1.29
 
 - Added support for Ghidra 12.0.

--- a/src/main/java/ghidra/emotionengine/EE_ElfExtension.java
+++ b/src/main/java/ghidra/emotionengine/EE_ElfExtension.java
@@ -86,9 +86,9 @@ public class EE_ElfExtension extends MIPS_ElfExtension {
 			// case SHT_MIPS_IOPMOD_VALUE:
 			// 	section = new IopModSection(shdr, helper);
 			// 	break;
-			case SHT_DVP_OVERLAY_TABLE_VALUE:
-				section = new DvpOverlayTable(shdr, helper);
-				break;
+			// case SHT_DVP_OVERLAY_TABLE_VALUE:
+			//	section = new DvpOverlayTable(shdr, helper);
+			//	break;
 			default:
 				section = null;
 				break;
@@ -101,9 +101,10 @@ public class EE_ElfExtension extends MIPS_ElfExtension {
 							createHeapSection(helper, shdr);
 						}
 					}
-				} else {
-					section.parse(monitor);
 				}
+				//} else {
+				//	section.parse(monitor);
+				//}
 			} catch (Exception e) {
 				helper.log(e);
 			}


### PR DESCRIPTION
Temporary fix to make the symbol tree usable again.