### PR TITLE
CI: Update actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
@@ -13,18 +16,18 @@ jobs:
         ghidra: ["12.0.4", "12.0.3", "12.0.2", "12.0.1", "12.0", "11.4.3", "11.4.2", "11.4.1", "11.4"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.10"
+          gradle-version: "8.14.4"
       - name: Setup Ghidra
-        uses: antoniovazquezblanco/setup-ghidra@cacffdd46c5f53356e6a7822a2743a39f57d1958
+        uses: antoniovazquezblanco/setup-ghidra@029b00367e561cef07baacedb6de5e007a1ebc9a
         with:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ matrix.ghidra }}
@@ -35,7 +38,7 @@ jobs:
       - name: Build Extension
         run: gradle -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }} buildExtension
       - name: Release
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*ghidra-emotionengine-reloaded.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,18 @@ jobs:
         ghidra: ["12.0.4", "12.0.3", "12.0.2", "12.0.1", "12.0", "11.4.3", "11.4.2", "11.4.1", "11.4"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.10"
+          gradle-version: "8.14.4"
       - name: Setup Ghidra
-        uses: antoniovazquezblanco/setup-ghidra@cacffdd46c5f53356e6a7822a2743a39f57d1958
+        uses: antoniovazquezblanco/setup-ghidra@029b00367e561cef07baacedb6de5e007a1ebc9a
         with:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ matrix.ghidra }}

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
@@ -13,18 +16,18 @@ jobs:
         ghidra: ["12.0.4", "12.0.3", "12.0.2", "12.0.1", "12.0", "11.4.3", "11.4.2", "11.4.1", "11.4"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: "8.10"
+          gradle-version: "8.14.4"
       - name: Setup Ghidra
-        uses: antoniovazquezblanco/setup-ghidra@cacffdd46c5f53356e6a7822a2743a39f57d1958
+        uses: antoniovazquezblanco/setup-ghidra@029b00367e561cef07baacedb6de5e007a1ebc9a
         with:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ matrix.ghidra }}
@@ -33,7 +36,7 @@ jobs:
       - name: Build Extension
         run: gradle -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }} buildExtension
       - name: Release
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*ghidra-emotionengine-reloaded.zip


### PR DESCRIPTION
* Bump actions to latest
* Use latest gradle 8
* ~~Use v2 tag for setup-ghidra instead of specific commit~~ bumps to https://github.com/antoniovazquezblanco/setup-ghidra/commit/029b00367e561cef07baacedb6de5e007a1ebc9a

Verified the CI runs on my fork:

Release:
https://github.com/dreamsyntax/ghidra-emotionengine-reloaded/releases/tag/v4
https://github.com/dreamsyntax/ghidra-emotionengine-reloaded/actions/runs/25020817220

'unstable' on push to main:
https://github.com/dreamsyntax/ghidra-emotionengine-reloaded/releases/tag/unstable
https://github.com/dreamsyntax/ghidra-emotionengine-reloaded/actions/runs/25020640579

test:
https://github.com/dreamsyntax/ghidra-emotionengine-reloaded/actions/runs/25020640571